### PR TITLE
MANUAL MERGE: merge upstream changes to 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -248,34 +248,30 @@ jobs:
                   -m "Generated v$LFS_VERSION_MAJOR prefixes")
           git reset --hard
           # Update major version branches (vN and vN-prefix)
-          git push https://$GEKY_BOT_RELEASES@github.com/$TRAVIS_REPO_SLUG.git \
+          git push --atomic https://$GEKY_BOT_RELEASES@github.com/$TRAVIS_REPO_SLUG.git \
               v$LFS_VERSION_MAJOR \
               v$LFS_VERSION_MAJOR-prefix
-          # Create patch version tag (vN.N.N)
-          curl -f -u "$GEKY_BOT_RELEASES" -X POST \
-              https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs \
-              -d "{
-                  \"ref\": \"refs/tags/$LFS_VERSION\",
-                  \"sha\": \"$TRAVIS_COMMIT\"
-              }"
-          # Create minor release?
-          [[ "$LFS_VERSION" == *.0 ]] || exit 0
           # Build release notes
-          PREV=$(git tag --sort=-v:refname -l "v*.0" | head -1)
+          PREV=$(git tag --sort=-v:refname -l "v*" | head -1)
           if [ ! -z "$PREV" ]
           then
               echo "PREV $PREV"
-              CHANGES=$'### Changes\n\n'$( \
-                  git log --oneline $PREV.. --grep='^Merge' --invert-grep)
+              CHANGES=$(git log --oneline $PREV.. --grep='^Merge' --invert-grep)
               printf "CHANGES\n%s\n\n" "$CHANGES"
           fi
-          # Create the release
+          case ${GEKY_BOT_DRAFT:-minor} in
+              true)  DRAFT=true ;;
+              minor) DRAFT=$(jq -R 'endswith(".0")' <<< "$LFS_VERSION") ;;
+              false) DRAFT=false ;;
+          esac
+          # Create the release and patch version tag (vN.N.N)
           curl -f -u "$GEKY_BOT_RELEASES" -X POST \
               https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases \
               -d "{
                   \"tag_name\": \"$LFS_VERSION\",
                   \"name\": \"${LFS_VERSION%.0}\",
-                  \"draft\": true,
+                  \"target_commitish\": \"$TRAVIS_COMMIT\",
+                  \"draft\": $DRAFT,
                   \"body\": $(jq -sR '.' <<< "$CHANGES")
               }" #"
           SCRIPT

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ override CFLAGS += -DLFS_YES_TRACE
 endif
 override CFLAGS += -I.
 override CFLAGS += -std=c99 -Wall -pedantic
-override CFLAGS += -Wextra -Wshadow -Wjump-misses-init
+override CFLAGS += -Wextra -Wshadow -Wjump-misses-init -Wundef
 # Remove missing-field-initializers because of GCC bug
 override CFLAGS += -Wno-missing-field-initializers
 

--- a/lfs.c
+++ b/lfs.c
@@ -2329,6 +2329,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
     file->cfg = cfg;
     file->flags = flags | LFS_F_OPENED;
     file->pos = 0;
+    file->off = 0;
     file->cache.buffer = NULL;
 
     // allocate entry for file if it doesn't exist

--- a/lfs.c
+++ b/lfs.c
@@ -3412,10 +3412,10 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs_cache_zero(lfs, &lfs->rcache);
     lfs_cache_zero(lfs, &lfs->pcache);
 
-    // setup lookahead, must be multiple of 64-bits
+    // setup lookahead, must be multiple of 64-bits, 32-bit aligned
     LFS_ASSERT(lfs->cfg->lookahead_size > 0);
     LFS_ASSERT(lfs->cfg->lookahead_size % 8 == 0 &&
-            (uintptr_t)lfs->cfg->lookahead_buffer % 8 == 0);
+            (uintptr_t)lfs->cfg->lookahead_buffer % 4 == 0);
     if (lfs->cfg->lookahead_buffer) {
         lfs->free.buffer = lfs->cfg->lookahead_buffer;
     } else {

--- a/lfs.c
+++ b/lfs.c
@@ -2981,6 +2981,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
         return LFS_ERR_INVAL;
     }
 
+    lfs_off_t pos = file->pos;
     lfs_off_t oldsize = lfs_file_size(lfs, file);
     if (size < oldsize) {
         // need to flush since directly changing metadata
@@ -3003,8 +3004,6 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
         file->ctz.size = size;
         file->flags |= LFS_F_DIRTY | LFS_F_READING;
     } else if (size > oldsize) {
-        lfs_off_t pos = file->pos;
-
         // flush+seek if not already at end
         if (file->pos != oldsize) {
             int err = lfs_file_seek(lfs, file, 0, LFS_SEEK_END);
@@ -3022,13 +3021,13 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
                 return res;
             }
         }
+    }
 
-        // restore pos
-        int err = lfs_file_seek(lfs, file, pos, LFS_SEEK_SET);
-        if (err < 0) {
-            LFS_TRACE("lfs_file_truncate -> %d", err);
-            return err;
-        }
+    // restore pos
+    int err = lfs_file_seek(lfs, file, pos, LFS_SEEK_SET);
+    if (err < 0) {
+      LFS_TRACE("lfs_file_truncate -> %d", err);
+      return err;
     }
 
     LFS_TRACE("lfs_file_truncate -> %d", 0);

--- a/lfs.c
+++ b/lfs.c
@@ -1500,7 +1500,7 @@ static int lfs_dir_compact(lfs_t *lfs,
                     end = begin;
                 }
             }
-#if LFS_MIGRATE
+#ifdef LFS_MIGRATE
         } else if (lfs_pair_cmp(dir->pair, lfs->root) == 0 && lfs->lfs1) {
             // we can't relocate our root during migrations, as this would
             // cause the superblock to get updated, which would clobber v1


### PR DESCRIPTION
This merges the upstream release of littlefs v2.1.1 into the Zephyr branch.  All non-Zephyr patches that were present in the Zephyr fork have been merged upstream.

This PR should not be merged through the github UI as it cannot preserve history correctly.  Rather the top merge commit fe9572dd5a9fcf93a249daa4233012692bd2881d may be pushed to the zephyr branch after an approving review.