### PR TITLE
lfs_util: fix log declaration when logging is disabled

### DIFF
--- a/lfs_util.h
+++ b/lfs_util.h
@@ -47,7 +47,7 @@
 #ifdef LFS_LOG_REGISTER
 LOG_MODULE_REGISTER(littlefs, CONFIG_FS_LOG_LEVEL);
 #else
-LOG_MODULE_DECLARE(littlefs);
+LOG_MODULE_DECLARE(littlefs, CONFIG_FS_LOG_LEVEL);
 #endif
 
 #endif  /* __ZEPHYR__ */


### PR DESCRIPTION
The same log level must be passed to LOG_MODULE_DECLARE() as was
passed to LOG_MODULE_REGISTER() or references will be generated in
cases when no infrastructure is defined.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>