### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -8,7 +8,7 @@
 #include "lfs_util.h"
 
 #ifdef __ZEPHYR__
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(littlefs, CONFIG_FS_LOG_LEVEL);
 #endif
 


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.